### PR TITLE
Improve TS types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,12 +86,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,12 +107,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.35"
+name = "once_cell"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392a54546fda6b7cc663379d0e6ce8b324cf88aecc5a499838e1be9781bdce2e"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -155,9 +155,9 @@ checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
@@ -176,13 +176,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.69",
 ]
 
 [[package]]
@@ -208,6 +208,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201fcda3845c23e8212cd466bfebf0bd20694490fc0356ae8e428e0824a915a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,8 +235,14 @@ checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.84",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-xid"
@@ -235,9 +252,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -247,24 +264,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.69",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -272,22 +289,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.69",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wee_alloc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ repository = "https://github.com/mpizenberg/elm-solve-deps-wasm"
 license = "MPL-2.0"
 keywords = ["dependency", "pubgrub", "solver", "version", "elm"]
 categories = ["algorithms"]
-rust-version = "1.56.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/mpizenberg/elm-solve-deps-wasm"
 license = "MPL-2.0"
 keywords = ["dependency", "pubgrub", "solver", "version", "elm"]
 categories = ["algorithms"]
+rust-version = "1.56.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/example-offline/dependency-provider-offline.js
+++ b/example-offline/dependency-provider-offline.js
@@ -20,7 +20,7 @@ export function fetchElmJson(pkg, version) {
       return fs.readFileSync(cacheElmJsonPath(pkg, version), "utf8");
     } catch {
       let remoteUrl = remoteElmJsonUrl(pkg, version);
-      throw `Not doing a remote request to ${remoteUrl}. Please run at least once elm-test first.`;
+      throw `Not doing a remote request to ${remoteUrl}. Please run elm-test at least once first.`;
     }
   }
 }
@@ -39,7 +39,7 @@ export function listAvailableVersions(pkg) {
   } catch {
     console.log(`Directory "${homePkgPath(pkg)} does not exist`);
     console.log(
-      `Not doing a request to the package server to find out existing versions. Please run at least once elm-test first.`,
+      `Not doing a request to the package server to find out existing versions. Please run elm-test at least once first.`,
     );
     return [];
   }

--- a/example-offline/dependency-provider-offline.js
+++ b/example-offline/dependency-provider-offline.js
@@ -1,8 +1,8 @@
 // @ts-check
-let fs = require("fs");
-let os = require("os");
-let path = require("path");
-let process = require("process");
+let fs = require("node:fs");
+let os = require("node:os");
+let path = require("node:path");
+let process = require("node:process");
 
 /**
  * Rust: `fetchElmJson(pkg: &str, version: &str) -> String`

--- a/example-offline/dependency-provider-offline.js
+++ b/example-offline/dependency-provider-offline.js
@@ -27,7 +27,7 @@ module.exports.listAvailableVersions = function listAvailableVersions(pkg) {
   } catch (_) {
     console.log(`Directory "${homePkgPath(pkg)} does not exist`);
     console.log(
-      `Not doing a request to the package server to find out existing versions. Please run at least once elm-test first.`
+      `Not doing a request to the package server to find out existing versions. Please run at least once elm-test first.`,
     );
     return [];
   }
@@ -51,7 +51,7 @@ function cacheElmJsonPath(pkg, version) {
     parts.author,
     parts.pkg,
     version,
-    "elm.json"
+    "elm.json",
   );
 }
 

--- a/example-offline/dependency-provider-offline.js
+++ b/example-offline/dependency-provider-offline.js
@@ -15,10 +15,10 @@ export function fetchElmJson(pkg, version) {
   // console.log("Fetching: " + pkg + " @ " + version);
   try {
     return fs.readFileSync(homeElmJsonPath(pkg, version), "utf8");
-  } catch (_) {
+  } catch {
     try {
       return fs.readFileSync(cacheElmJsonPath(pkg, version), "utf8");
-    } catch (_) {
+    } catch {
       let remoteUrl = remoteElmJsonUrl(pkg, version);
       throw `Not doing a remote request to ${remoteUrl}. Please run at least once elm-test first.`;
     }
@@ -36,7 +36,7 @@ export function listAvailableVersions(pkg) {
   let subdirectories;
   try {
     subdirectories = fs.readdirSync(homePkgPath(pkg));
-  } catch (_) {
+  } catch {
     console.log(`Directory "${homePkgPath(pkg)} does not exist`);
     console.log(
       `Not doing a request to the package server to find out existing versions. Please run at least once elm-test first.`,

--- a/example-offline/dependency-provider-offline.js
+++ b/example-offline/dependency-provider-offline.js
@@ -1,8 +1,8 @@
 // @ts-check
-let fs = require("node:fs");
-let os = require("node:os");
-let path = require("node:path");
-let process = require("node:process");
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
 
 /**
  * Rust: `fetchElmJson(pkg: &str, version: &str) -> String`
@@ -11,7 +11,7 @@ let process = require("node:process");
  * @param {string} version
  * @returns {string}
  */
-module.exports.fetchElmJson = function fetchElmJson(pkg, version) {
+export function fetchElmJson(pkg, version) {
   // console.log("Fetching: " + pkg + " @ " + version);
   try {
     return fs.readFileSync(homeElmJsonPath(pkg, version), "utf8");
@@ -23,7 +23,7 @@ module.exports.fetchElmJson = function fetchElmJson(pkg, version) {
       throw `Not doing a remote request to ${remoteUrl}. Please run at least once elm-test first.`;
     }
   }
-};
+}
 
 /**
  * Rust: `listAvailableVersions(pkg: &str) -> Vec<String>`
@@ -31,7 +31,7 @@ module.exports.fetchElmJson = function fetchElmJson(pkg, version) {
  * @param {string} pkg
  * @returns {string[]}
  */
-module.exports.listAvailableVersions = function listAvailableVersions(pkg) {
+export function listAvailableVersions(pkg) {
   // console.log("List versions of: " + pkg);
   let subdirectories;
   try {
@@ -46,7 +46,7 @@ module.exports.listAvailableVersions = function listAvailableVersions(pkg) {
 
   // Reverse order of subdirectories to have newest versions first.
   return subdirectories.reverse();
-};
+}
 
 // Helper functions ##################################################
 

--- a/example-offline/dependency-provider-offline.js
+++ b/example-offline/dependency-provider-offline.js
@@ -1,9 +1,16 @@
+// @ts-check
 let fs = require("fs");
 let os = require("os");
 let path = require("path");
 let process = require("process");
 
-// fetchElmJson(pkg: &str, version: &str) -> String;
+/**
+ * Rust: `fetchElmJson(pkg: &str, version: &str) -> String`
+ *
+ * @param {string} pkg
+ * @param {string} version
+ * @returns {string}
+ */
 module.exports.fetchElmJson = function fetchElmJson(pkg, version) {
   // console.log("Fetching: " + pkg + " @ " + version);
   try {
@@ -18,7 +25,12 @@ module.exports.fetchElmJson = function fetchElmJson(pkg, version) {
   }
 };
 
-// listAvailableVersions(pkg: &str) -> Vec<JsValue>;
+/**
+ * Rust: `listAvailableVersions(pkg: &str) -> Vec<String>`
+ *
+ * @param {string} pkg
+ * @returns {string[]}
+ */
 module.exports.listAvailableVersions = function listAvailableVersions(pkg) {
   // console.log("List versions of: " + pkg);
   let subdirectories;
@@ -85,5 +97,5 @@ function defaultUnixElmHome() {
 }
 
 function defaultWindowsElmHome() {
-  return path.join(process.env.APPDATA, "elm");
+  return path.join(process.env.APPDATA ?? "", "elm");
 }

--- a/example-offline/index.js
+++ b/example-offline/index.js
@@ -32,7 +32,7 @@ let solution = wasm.solve_deps(
   false,
   {},
   depsProvider.fetchElmJson,
-  depsProvider.listAvailableVersions
+  depsProvider.listAvailableVersions,
 );
 
 console.log(JSON.parse(solution));

--- a/example-offline/index.js
+++ b/example-offline/index.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-check
 let depsProvider = require("./dependency-provider-offline.js");
 let wasm = require("elm-solve-deps-wasm");
 wasm.init();

--- a/example-offline/index.js
+++ b/example-offline/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 let depsProvider = require("./dependency-provider-offline.js");
 let wasm = require("elm-solve-deps-wasm");
 wasm.init();

--- a/example-offline/index.js
+++ b/example-offline/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // @ts-check
-let depsProvider = require("./dependency-provider-offline.js");
-let wasm = require("elm-solve-deps-wasm");
+import * as depsProvider from "./dependency-provider-offline.js";
+import wasm from "elm-solve-deps-wasm";
 wasm.init();
 
 let elm_json_config = `

--- a/example-offline/package-lock.json
+++ b/example-offline/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "elm-deps",
+  "name": "elm-deps-offline",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "elm-deps",
+      "name": "elm-deps-offline",
       "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {

--- a/example-offline/package-lock.json
+++ b/example-offline/package-lock.json
@@ -1,11 +1,25 @@
 {
   "name": "elm-deps",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "elm-solve-deps-wasm": {
-      "version": "file:../pkg"
+  "packages": {
+    "": {
+      "name": "elm-deps",
+      "version": "1.0.0",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "elm-solve-deps-wasm": "file:../pkg"
+      }
+    },
+    "../pkg": {
+      "name": "elm-solve-deps-wasm",
+      "version": "1.0.2",
+      "license": "MPL-2.0"
+    },
+    "node_modules/elm-solve-deps-wasm": {
+      "resolved": "../pkg",
+      "link": true
     }
   }
 }

--- a/example-offline/package.json
+++ b/example-offline/package.json
@@ -1,6 +1,7 @@
 {
   "name": "elm-deps-offline",
   "private": true,
+  "type": "module",
   "version": "1.0.0",
   "description": "Example usage of elm-solve-deps-wasm",
   "main": "index.js",

--- a/example-offline/package.json
+++ b/example-offline/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "elm-deps",
+  "name": "elm-deps-offline",
+  "private": true,
   "version": "1.0.0",
   "description": "Example usage of elm-solve-deps-wasm",
   "main": "index.js",

--- a/example-online/Solver/DependencyProvider.js
+++ b/example-online/Solver/DependencyProvider.js
@@ -1,11 +1,11 @@
 // @flow
 
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
-const wasm = require('elm-solve-deps-wasm');
-const SyncGet = require('./SyncGet.js');
-const collator = new Intl.Collator('en', { numeric: true }); // for sorting SemVer strings
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const wasm = require("elm-solve-deps-wasm");
+const SyncGet = require("./SyncGet.js");
+const collator = new Intl.Collator("en", { numeric: true }); // for sorting SemVer strings
 
 // Initialization work done only once.
 wasm.init();
@@ -23,7 +23,7 @@ const listVersionsMemoCache /*: Map<string, Array<string>> */ = new Map();
 function solveOffline(
   elmJson /*: string */,
   useTest /*: boolean */,
-  extra /*: { [string]: string } */
+  extra /*: { [string]: string } */,
 ) /*: string */ {
   listVersionsMemoCache.clear();
   try {
@@ -32,7 +32,7 @@ function solveOffline(
       useTest,
       extra,
       fetchElmJsonOffline,
-      listAvailableVersionsOffline
+      listAvailableVersionsOffline,
     );
   } catch (errorMessage) {
     throw new Error(errorMessage);
@@ -43,7 +43,7 @@ function solveOffline(
 function solveOnline(
   elmJson /*: string */,
   useTest /*: boolean */,
-  extra /*: { [string]: string } */
+  extra /*: { [string]: string } */,
 ) /*: string */ {
   updateOnlineVersionsCache();
   listVersionsMemoCache.clear();
@@ -53,7 +53,7 @@ function solveOnline(
       useTest,
       extra,
       fetchElmJsonOnline,
-      listAvailableVersionsOnline
+      listAvailableVersionsOnline,
     );
   } catch (errorMessage) {
     throw new Error(errorMessage);
@@ -62,7 +62,7 @@ function solveOnline(
 
 function fetchElmJsonOnline(
   pkg /*: string */,
-  version /*: string */
+  version /*: string */,
 ) /*: string */ {
   try {
     return fetchElmJsonOffline(pkg, version);
@@ -83,31 +83,31 @@ function fetchElmJsonOnline(
 
 function fetchElmJsonOffline(
   pkg /*: string */,
-  version /*: string */
+  version /*: string */,
 ) /*: string */ {
   try {
-    return fs.readFileSync(homeElmJsonPath(pkg, version), 'utf8');
+    return fs.readFileSync(homeElmJsonPath(pkg, version), "utf8");
   } catch (_) {
     // The read can only fail if the elm.json file does not exist
     // or if we don't have the permissions to read it so it's fine to catch all.
     // Otherwise, it means that `homeElmJsonPath()` failed while processing `pkg` and `version`.
     // In such case, again, it's fine to catch all since the next call to `cacheElmJsonPath()`
     // will fail the same anyway.
-    return fs.readFileSync(cacheElmJsonPath(pkg, version), 'utf8');
+    return fs.readFileSync(cacheElmJsonPath(pkg, version), "utf8");
   }
 }
 
 // Update the `onlineVersionsCache` global variable.
 function updateOnlineVersionsCache() /*: void */ {
-  const pubgrubHome = path.join(elmHome(), 'pubgrub');
+  const pubgrubHome = path.join(elmHome(), "pubgrub");
   fs.mkdirSync(pubgrubHome, { recursive: true });
-  const cachePath = path.join(pubgrubHome, 'versions_cache.json');
-  const remotePackagesUrl = 'https://package.elm-lang.org/all-packages';
+  const cachePath = path.join(pubgrubHome, "versions_cache.json");
+  const remotePackagesUrl = "https://package.elm-lang.org/all-packages";
   if (onlineVersionsCache.size === 0) {
     let cacheFile;
     try {
       // Read from disk existing versions which are already cached.
-      cacheFile = fs.readFileSync(cachePath, 'utf8');
+      cacheFile = fs.readFileSync(cachePath, "utf8");
     } catch (_) {
       // The cache file does not exist so let's reset it.
       updateCacheFromScratch(cachePath, remotePackagesUrl);
@@ -117,7 +117,7 @@ function updateOnlineVersionsCache() /*: void */ {
       onlineVersionsCache = parseOnlineVersions(JSON.parse(cacheFile));
     } catch (error) {
       throw new Error(
-        `Failed to parse the cache file ${cachePath}.\n${error.message}`
+        `Failed to parse the cache file ${cachePath}.\n${error.message}`,
       );
     }
   }
@@ -128,7 +128,7 @@ function updateOnlineVersionsCache() /*: void */ {
 // with a request to the package server.
 function updateCacheFromScratch(
   cachePath /*: string */,
-  remotePackagesUrl /*: string */
+  remotePackagesUrl /*: string */,
 ) /*: void */ {
   const onlineVersionsJson = syncGetWorker.get(remotePackagesUrl);
   fs.writeFileSync(cachePath, onlineVersionsJson);
@@ -137,7 +137,7 @@ function updateCacheFromScratch(
     onlineVersionsCache = parseOnlineVersions(onlineVersions);
   } catch (error) {
     throw new Error(
-      `Failed to parse the response from the request to ${remotePackagesUrl}.\n${error.message}`
+      `Failed to parse the response from the request to ${remotePackagesUrl}.\n${error.message}`,
     );
   }
 }
@@ -145,7 +145,7 @@ function updateCacheFromScratch(
 // Update the cache with a request to the package server.
 function updateCacheWithRequestSince(
   cachePath /*: string */,
-  remotePackagesUrl /*: string */
+  remotePackagesUrl /*: string */,
 ) /*: void */ {
   // Count existing versions.
   let versionsCount = 0;
@@ -154,7 +154,7 @@ function updateCacheWithRequestSince(
   }
 
   // Complete cache with a remote call to the package server.
-  const remoteUrl = remotePackagesUrl + '/since/' + (versionsCount - 1); // -1 to check if no package was deleted.
+  const remoteUrl = remotePackagesUrl + "/since/" + (versionsCount - 1); // -1 to check if no package was deleted.
   const newVersions = JSON.parse(syncGetWorker.get(remoteUrl));
   if (newVersions.length === 0) {
     // Reload from scratch since it means at least one package was deleted from the registry.
@@ -239,13 +239,13 @@ function semverCompare(a /*: string */, b /*: string */) /*: number */ {
 }
 
 function parseOnlineVersions(
-  json /*: mixed */
+  json /*: mixed */,
 ) /*: Map<string, Array<string>> */ {
-  if (typeof json !== 'object' || json === null || Array.isArray(json)) {
+  if (typeof json !== "object" || json === null || Array.isArray(json)) {
     throw new Error(
       `Expected an object, but got: ${
-        json === null ? 'null' : Array.isArray(json) ? 'Array' : typeof json
-      }`
+        json === null ? "null" : Array.isArray(json) ? "Array" : typeof json
+      }`,
     );
   }
 
@@ -260,20 +260,20 @@ function parseOnlineVersions(
 
 function parseVersions(
   key /*: string */,
-  json /*: mixed */
+  json /*: mixed */,
 ) /*: Array<string> */ {
   if (!Array.isArray(json)) {
     throw new Error(
-      `Expected ${JSON.stringify(key)} to be an array, but got: ${typeof json}`
+      `Expected ${JSON.stringify(key)} to be an array, but got: ${typeof json}`,
     );
   }
 
   for (const [index, item] of json.entries()) {
-    if (typeof item !== 'string') {
+    if (typeof item !== "string") {
       throw new Error(
         `Expected${JSON.stringify(
-          key
-        )}->${index} to be a string, but got: ${typeof item}`
+          key,
+        )}->${index} to be a string, but got: ${typeof item}`,
       );
     }
   }
@@ -284,44 +284,44 @@ function parseVersions(
 
 function remoteElmJsonUrl(
   pkg /*: string */,
-  version /*: string */
+  version /*: string */,
 ) /*: string */ {
   return `https://package.elm-lang.org/packages/${pkg}/${version}/elm.json`;
 }
 
 function cacheElmJsonPath(
   pkg /*: string */,
-  version /*: string */
+  version /*: string */,
 ) /*: string */ {
   const parts = splitAuthorPkg(pkg);
   return path.join(
     elmHome(),
-    'pubgrub',
-    'elm_json_cache',
+    "pubgrub",
+    "elm_json_cache",
     parts.author,
     parts.pkg,
     version,
-    'elm.json'
+    "elm.json",
   );
 }
 
 function homeElmJsonPath(
   pkg /*: string */,
-  version /*: string */
+  version /*: string */,
 ) /*: string */ {
-  return path.join(homePkgPath(pkg), version, 'elm.json');
+  return path.join(homePkgPath(pkg), version, "elm.json");
 }
 
 function homePkgPath(pkg /*: string */) /*: string */ {
   const parts = splitAuthorPkg(pkg);
-  return path.join(elmHome(), '0.19.1', 'packages', parts.author, parts.pkg);
+  return path.join(elmHome(), "0.19.1", "packages", parts.author, parts.pkg);
 }
 
 function splitAuthorPkg(pkgIdentifier /*: string */) /*: {
   author: string,
   pkg: string,
 } */ {
-  const parts = pkgIdentifier.split('/');
+  const parts = pkgIdentifier.split("/");
   return { author: parts[0], pkg: parts[1] };
 }
 
@@ -329,32 +329,32 @@ function splitPkgVersion(str /*: string */) /*: {
   pkg: string,
   version: string,
 } */ {
-  const parts = str.split('@');
+  const parts = str.split("@");
   return { pkg: parts[0], version: parts[1] };
 }
 
 function elmHome() /*: string */ {
-  const elmHomeEnv = process.env['ELM_HOME'];
+  const elmHomeEnv = process.env["ELM_HOME"];
   return elmHomeEnv === undefined ? defaultElmHome() : elmHomeEnv;
 }
 
 function defaultElmHome() /*: string */ {
-  return process.platform === 'win32'
+  return process.platform === "win32"
     ? defaultWindowsElmHome()
     : defaultUnixElmHome();
 }
 
 function defaultUnixElmHome() /*: string */ {
-  return path.join(os.homedir(), '.elm');
+  return path.join(os.homedir(), ".elm");
 }
 
 function defaultWindowsElmHome() /*: string */ {
   const appData = process.env.APPDATA;
   const dir =
     appData === undefined
-      ? path.join(os.homedir(), 'AppData', 'Roaming')
+      ? path.join(os.homedir(), "AppData", "Roaming")
       : appData;
-  return path.join(dir, 'elm');
+  return path.join(dir, "elm");
 }
 
 module.exports = {

--- a/example-online/Solver/DependencyProvider.js
+++ b/example-online/Solver/DependencyProvider.js
@@ -1,7 +1,7 @@
 // @ts-check
-const fs = require("fs");
-const os = require("os");
-const path = require("path");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
 const wasm = require("elm-solve-deps-wasm");
 const SyncGet = require("./SyncGet.js");
 const collator = new Intl.Collator("en", { numeric: true }); // for sorting SemVer strings

--- a/example-online/Solver/DependencyProvider.js
+++ b/example-online/Solver/DependencyProvider.js
@@ -1,13 +1,13 @@
 // @ts-check
-const fs = require("node:fs");
-const os = require("node:os");
-const path = require("node:path");
-const wasm = require("elm-solve-deps-wasm");
-const SyncGet = require("./SyncGet.js");
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import * as SyncGet from "./SyncGet.js";
+import wasm from "elm-solve-deps-wasm";
+wasm.init(); // Initialization work done only once.
+
 const collator = new Intl.Collator("en", { numeric: true }); // for sorting SemVer strings
 
-// Initialization work done only once.
-wasm.init();
 /** @type {{ get: (string: string) => string, shutDown: () => void }} */
 const syncGetWorker = SyncGet.startWorker();
 
@@ -427,7 +427,4 @@ function defaultWindowsElmHome() {
   return path.join(dir, "elm");
 }
 
-module.exports = {
-  solveOffline,
-  solveOnline,
-};
+export { solveOffline, solveOnline };

--- a/example-online/Solver/SyncGet.js
+++ b/example-online/Solver/SyncGet.js
@@ -1,10 +1,10 @@
 // @ts-check
-const path = require("node:path");
-const {
+import path from "node:path";
+import {
   Worker,
   MessageChannel,
   receiveMessageOnPort,
-} = require("node:worker_threads");
+} from "node:worker_threads";
 
 /**
  * Start a worker thread.
@@ -39,6 +39,4 @@ function startWorker() {
   return { get, shutDown };
 }
 
-module.exports = {
-  startWorker,
-};
+export { startWorker };

--- a/example-online/Solver/SyncGet.js
+++ b/example-online/Solver/SyncGet.js
@@ -1,10 +1,10 @@
 // @ts-check
-const path = require("path");
+const path = require("node:path");
 const {
   Worker,
   MessageChannel,
   receiveMessageOnPort,
-} = require("worker_threads");
+} = require("node:worker_threads");
 
 /**
  * Start a worker thread.

--- a/example-online/Solver/SyncGet.js
+++ b/example-online/Solver/SyncGet.js
@@ -1,12 +1,12 @@
 // @flow
 
-const path = require('path');
+const path = require("path");
 const {
   Worker,
   MessageChannel,
   receiveMessageOnPort,
   // $FlowFixMe[cannot-resolve-module]: Flow doesn’t seem to know about the `worker_threads` module yet.
-} = require('worker_threads');
+} = require("worker_threads");
 
 // Start a worker thread and return a `syncGetWorker`
 // capable of making sync requests until shut down.
@@ -18,7 +18,7 @@ function startWorker() /*: {
   const sharedLock = new SharedArrayBuffer(4);
   // $FlowFixMe[incompatible-call]: Flow is wrong and says `sharedLock` is not an accepted parameter here.
   const sharedLockArray = new Int32Array(sharedLock);
-  const workerPath = path.resolve(__dirname, 'SyncGetWorker.js');
+  const workerPath = path.resolve(__dirname, "SyncGetWorker.js");
   const worker = new Worker(workerPath, {
     workerData: { sharedLock, requestPort: workerPort },
     transferList: [workerPort],

--- a/example-online/Solver/SyncGet.js
+++ b/example-online/Solver/SyncGet.js
@@ -1,22 +1,21 @@
-// @flow
-
+// @ts-check
 const path = require("path");
 const {
   Worker,
   MessageChannel,
   receiveMessageOnPort,
-  // $FlowFixMe[cannot-resolve-module]: Flow doesn’t seem to know about the `worker_threads` module yet.
 } = require("worker_threads");
 
-// Start a worker thread and return a `syncGetWorker`
-// capable of making sync requests until shut down.
-function startWorker() /*: {
-  get: (string) => string,
-  shutDown: () => void,
-} */ {
+/**
+ * Start a worker thread.
+ *
+ *
+ * @returns {{ get: (string: string) => string, shutDown: () => void }}
+ *  a `syncGetWorker` capable of making sync requests until shut down.
+ */
+function startWorker() {
   const { port1: localPort, port2: workerPort } = new MessageChannel();
   const sharedLock = new SharedArrayBuffer(4);
-  // $FlowFixMe[incompatible-call]: Flow is wrong and says `sharedLock` is not an accepted parameter here.
   const sharedLockArray = new Int32Array(sharedLock);
   const workerPath = path.resolve(__dirname, "SyncGetWorker.js");
   const worker = new Worker(workerPath, {
@@ -27,10 +26,10 @@ function startWorker() /*: {
     worker.postMessage(url);
     Atomics.wait(sharedLockArray, 0, 0); // blocks until notified at index 0.
     const response = receiveMessageOnPort(localPort);
-    if (response.message.error) {
-      throw response.message.error;
+    if (response?.message.error) {
+      throw response?.message.error;
     } else {
-      return response.message;
+      return response?.message;
     }
   }
   function shutDown() {

--- a/example-online/Solver/SyncGetWorker.js
+++ b/example-online/Solver/SyncGetWorker.js
@@ -1,13 +1,13 @@
 // @flow
 
 // $FlowFixMe[cannot-resolve-module]: Flow doesn’t seem to know about the `worker_threads` module yet.
-const { parentPort, workerData } = require('worker_threads');
-const https = require('https');
+const { parentPort, workerData } = require("worker_threads");
+const https = require("https");
 
 const { sharedLock, requestPort } = workerData;
 const sharedLockArray = new Int32Array(sharedLock);
 
-parentPort.on('message', async (url) => {
+parentPort.on("message", async (url) => {
   try {
     const response = await getBody(url);
     requestPort.postMessage(response);
@@ -21,15 +21,15 @@ async function getBody(url /*: string */) /*: Promise<string> */ {
   return new Promise(function (resolve, reject) {
     https
       .get(url, function (res) {
-        let body = '';
-        res.on('data', function (chunk) {
+        let body = "";
+        res.on("data", function (chunk) {
           body += chunk;
         });
-        res.on('end', function () {
+        res.on("end", function () {
           resolve(body);
         });
       })
-      .on('error', function (err) {
+      .on("error", function (err) {
         reject(err);
       });
   });

--- a/example-online/Solver/SyncGetWorker.js
+++ b/example-online/Solver/SyncGetWorker.js
@@ -1,6 +1,6 @@
 // @ts-check
-const { parentPort, workerData } = require("worker_threads");
-const https = require("https");
+const { parentPort, workerData } = require("node:worker_threads");
+const https = require("node:https");
 
 const { sharedLock, requestPort } = workerData;
 const sharedLockArray = new Int32Array(sharedLock);

--- a/example-online/Solver/SyncGetWorker.js
+++ b/example-online/Solver/SyncGetWorker.js
@@ -1,13 +1,11 @@
-// @flow
-
-// $FlowFixMe[cannot-resolve-module]: Flow doesn’t seem to know about the `worker_threads` module yet.
+// @ts-check
 const { parentPort, workerData } = require("worker_threads");
 const https = require("https");
 
 const { sharedLock, requestPort } = workerData;
 const sharedLockArray = new Int32Array(sharedLock);
 
-parentPort.on("message", async (url) => {
+parentPort?.on("message", async (url) => {
   try {
     const response = await getBody(url);
     requestPort.postMessage(response);
@@ -17,7 +15,11 @@ parentPort.on("message", async (url) => {
   Atomics.notify(sharedLockArray, 0, Infinity);
 });
 
-async function getBody(url /*: string */) /*: Promise<string> */ {
+/**
+ * @param {string} url
+ * @returns {Promise<string>}
+ */
+async function getBody(url) {
   return new Promise(function (resolve, reject) {
     https
       .get(url, function (res) {

--- a/example-online/Solver/SyncGetWorker.js
+++ b/example-online/Solver/SyncGetWorker.js
@@ -1,6 +1,6 @@
 // @ts-check
-const { parentPort, workerData } = require("node:worker_threads");
-const https = require("node:https");
+import { parentPort, workerData } from "node:worker_threads";
+import https from "node:https";
 
 const { sharedLock, requestPort } = workerData;
 const sharedLockArray = new Int32Array(sharedLock);

--- a/example-online/index.js
+++ b/example-online/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // @ts-check
-const process = require("node:process");
-const DependencyProvider = require("./Solver/DependencyProvider.js");
+import process from "node:process";
+import * as DependencyProvider from "./Solver/DependencyProvider.js";
 
 const elmJsonStr = `
 {

--- a/example-online/index.js
+++ b/example-online/index.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-check
 const process = require("process");
 const DependencyProvider = require("./Solver/DependencyProvider.js");
 
@@ -27,7 +28,11 @@ const elmJsonStr = `
 }
 `;
 
-function solveTestDependencies(elmJson /*: string */) /*: string */ {
+/**
+ * @param {string} elmJson
+ * @returns {string}
+ */
+function solveTestDependencies(elmJson) {
   const useTest = true;
   const extra = {
     "elm/core": "1.0.0 <= v < 2.0.0",

--- a/example-online/index.js
+++ b/example-online/index.js
@@ -42,7 +42,7 @@ function solveTestDependencies(elmJson) {
   };
   try {
     return DependencyProvider.solveOffline(elmJson, useTest, extra);
-  } catch (_) {
+  } catch {
     console.warn("Offline solver failed, switching to online solver.");
     return DependencyProvider.solveOnline(elmJson, useTest, extra);
   }

--- a/example-online/index.js
+++ b/example-online/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // @ts-check
-const process = require("process");
+const process = require("node:process");
 const DependencyProvider = require("./Solver/DependencyProvider.js");
 
 const elmJsonStr = `

--- a/example-online/index.js
+++ b/example-online/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const process = require("process");
 const DependencyProvider = require("./Solver/DependencyProvider.js");
 

--- a/example-online/package-lock.json
+++ b/example-online/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "elm-deps",
+  "name": "elm-deps-online",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "elm-deps",
+      "name": "elm-deps-online",
       "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {

--- a/example-online/package-lock.json
+++ b/example-online/package-lock.json
@@ -1,11 +1,25 @@
 {
   "name": "elm-deps",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "elm-solve-deps-wasm": {
-      "version": "file:../pkg"
+  "packages": {
+    "": {
+      "name": "elm-deps",
+      "version": "1.0.0",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "elm-solve-deps-wasm": "file:../pkg"
+      }
+    },
+    "../pkg": {
+      "name": "elm-solve-deps-wasm",
+      "version": "1.0.2",
+      "license": "MPL-2.0"
+    },
+    "node_modules/elm-solve-deps-wasm": {
+      "resolved": "../pkg",
+      "link": true
     }
   }
 }

--- a/example-online/package.json
+++ b/example-online/package.json
@@ -1,6 +1,7 @@
 {
   "name": "elm-deps-online",
   "private": true,
+  "type": "module",
   "version": "1.0.0",
   "description": "Example usage of elm-solve-deps-wasm",
   "main": "index.js",

--- a/example-online/package.json
+++ b/example-online/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "elm-deps",
+  "name": "elm-deps-online",
+  "private": true,
   "version": "1.0.0",
   "description": "Example usage of elm-solve-deps-wasm",
   "main": "index.js",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub fn solve_deps(
     additional_constraints_str: AdditionalConstraintsStr,
     js_fetch_elm_json: &JsFetchElmJson,
     js_list_available_versions: &JsListAvailableVersions,
-) -> Result<JsValue, JsValue> {
+) -> Result<String, JsValue> {
     // Load the elm.json of the package given as argument or of the current folder.
     let project_elm_json: ProjectConfig = serde_json::from_str(project_elm_json_str)
         .context("Failed to decode the elm.json")
@@ -138,7 +138,7 @@ pub fn solve_deps(
     ) {
         Ok(solution) => {
             let solution_json = serde_json::to_string(&solution).unwrap();
-            Ok(JsValue::from_str(&solution_json))
+            Ok(solution_json)
         }
         Err(err) => Err(utils::report_error(handle_pubgrub_error(err))),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,8 +93,7 @@ pub fn solve_deps(
                 let str_js_err =
                     js_sys::JSON::stringify(&js_err).unwrap_or_else(|_| js_sys::JsString::from(""));
                 Err(format!(
-                    "An error occurred in the JS function call `fetch_elm_json({}, {})`.\n\n{}",
-                    pkg, version, str_js_err
+                    "An error occurred in the JS function call `fetch_elm_json({pkg}, {version})`.\n\n{str_js_err}"
                 )
                 .into())
             }
@@ -114,8 +113,7 @@ pub fn solve_deps(
             let str_js_err =
                 js_sys::JSON::stringify(&js_err).unwrap_or_else(|_| js_sys::JsString::from(""));
             Err(format!(
-                "An error occurred in the JS function call `list_available_versions({})`.\n\n{}",
-                pkg, str_js_err
+                "An error occurred in the JS function call `list_available_versions({pkg})`.\n\n{str_js_err}"
             )
             .into())
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub fn init() {
 /// Include also test dependencies if `use_test` is `true`.
 /// It is possible to add additional constraints.
 /// The caller is responsible to provide implementations to be able to fetch the `elm.json` of
-/// dependencies, as well as to list existing versions (in prefered order) for a given package.
+/// dependencies, as well as to list existing versions (in preferred order) for a given package.
 #[wasm_bindgen]
 pub fn solve_deps(
     project_elm_json_str: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,6 @@ use pubgrub::report::{DefaultStringReporter, Reporter};
 use pubgrub::version::SemanticVersion as SemVer;
 use wee_alloc::WeeAlloc;
 
-// Useful references:
-// Returning Vec<T>: https://github.com/rustwasm/wasm-bindgen/issues/111
-
 use elm_solve_deps::constraint::Constraint;
 use elm_solve_deps::project_config::{Pkg, ProjectConfig};
 use elm_solve_deps::solver::solve_deps_with;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -36,7 +36,7 @@ impl WasmLogger {
         log::set_logger(&LOGGER)
     }
     pub fn setup(max_level: LevelFilter) {
-        log::set_max_level(max_level)
+        log::set_max_level(max_level);
     }
 }
 
@@ -66,7 +66,7 @@ pub fn verbosity_filter(verbosity: u32) -> LevelFilter {
     }
 }
 
-/// Log the error and convert it into a JsValue.
+/// Log the error and convert it into a `JsValue`.
 pub fn report_error<E: Into<anyhow::Error>>(error: E) -> JsValue {
     let error_msg = format!("{:?}", error.into());
     log::error!("{}", &error_msg);


### PR DESCRIPTION
Depends on #5
Here's the diff as GH doesn't play well with stacks from forks: <https://github.com/lishaduck/elm-solve-deps-wasm/compare/better-cargo+clippy...better-ts-types>

Removes `any` from the generated TS types.
The way the hashmap was handled made the minimal diff, but a more "correct" way of doing it would use `serde-wasm-bindgen` to serialize it.
The commit to update parameters should 100% make no difference to the generated wasm (as should the typo fix)
Dependency updates and the return type changes might make some differences, but I didn't notice tests. How should I check it works?

_**Closes:** #2_

P.S.: Correct me if I'm wrong, but I think the main consumer of this is elm-review. If elm-review does migrate to ESM, I'll be back! 😄